### PR TITLE
Fixes the plots being wierdly small on switch to bokeh 0.11.1

### DIFF
--- a/crem_presentation/site/content/viz/constants_styling.py
+++ b/crem_presentation/site/content/viz/constants_styling.py
@@ -42,5 +42,8 @@ PLOT_FORMATS = dict(
     responsive=True,
     toolbar_location=None,
     outline_line_color=None,
-    min_border=0
+    min_border_top=0,
+    min_border_right=0,
+    min_border_left=0,
+    min_border_bottom=0,
 )


### PR DESCRIPTION
This is a bokeh bug

This change is compatible with both bokeh 0.10 and bokeh 0.11.
